### PR TITLE
fix: include again 'purchaseDate' missing value by fixing the orders parsing method.

### DIFF
--- a/src/extension/content_scripts/script.js
+++ b/src/extension/content_scripts/script.js
@@ -135,7 +135,7 @@ function QuickReport(params) {
 
                 var sellerName = getInnerText(orders[order].querySelector('.order-item-count .seller-id'), '');
                 var sellerUrl = getAttribute(orders[order].querySelector('.order-item-count .seller-id'), 'href', '');
-                var purchaseDate = getInnerText(orders[order].querySelector('.order-row .purchase-header .row-date'), '');
+                var purchaseDate = getInnerText(orders[order].querySelector('.order-row .purchase-header .row-value'), '');
                 var orderItems = orders[order].querySelectorAll('.item-level-wrap');
 
                 var elapsedDays = dateDiff(dateParse(purchaseDate));


### PR DESCRIPTION

This also fixes the elapsedDay wrong value bug, since the date to compare with, will not be empty anymore.