### PR TITLE
Update script.js

### DIFF
--- a/src/extension/content_scripts/script.js
+++ b/src/extension/content_scripts/script.js
@@ -135,7 +135,7 @@ function QuickReport(params) {
 
                 var sellerName = getInnerText(orders[order].querySelector('.order-item-count .seller-id'), '');
                 var sellerUrl = getAttribute(orders[order].querySelector('.order-item-count .seller-id'), 'href', '');
-                var purchaseDate = getInnerText(orders[order].querySelector('.order-row .purchase-header .row-date'), '');
+                var purchaseDate = getInnerText(orders[order].querySelector('.order-row .purchase-header .row-value'), '');
                 var orderItems = orders[order].querySelectorAll('.item-level-wrap');
 
                 var elapsedDays = dateDiff(dateParse(purchaseDate));


### PR DESCRIPTION
As at 10th January 2020, the report no longer pushes the item's Purchase Date.

This is due to eBay modifying the page's HTML.
The item's Purchase Date class in the table has been changed from "row-date" to "row-value".

"var purchaseDate" now searches for ".row-value" instead of ".row-date".